### PR TITLE
fix warnings about unsupported number format exceptions in sbt

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.17


### PR DESCRIPTION
Hi,
I was trying to revive my PR for equality heathermiller/spores#56. Sbt welcomed me with many warning about a NumberFormatException. That was a issue with JLine and 'newer' Linux distrubutions and was in sbt 0.13.16 (sbt/sbt#3240).


Full error message:
```
[ERROR] Failed to construct terminal; falling back to unsupported
java.lang.NumberFormatException: For input string: "0x100"
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
        at java.lang.Integer.parseInt(Integer.java:580)
        at java.lang.Integer.valueOf(Integer.java:766)
        at jline.internal.InfoCmp.parseInfoCmp(InfoCmp.java:59)
        at jline.UnixTerminal.parseInfoCmp(UnixTerminal.java:233)
        at jline.UnixTerminal.<init>(UnixTerminal.java:64)
        at jline.UnixTerminal.<init>(UnixTerminal.java:49)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at java.lang.Class.newInstance(Class.java:442)
        at jline.TerminalFactory.getFlavor(TerminalFactory.java:209)
        at jline.TerminalFactory.create(TerminalFactory.java:100)
        at jline.TerminalFactory.get(TerminalFactory.java:184)
        at jline.TerminalFactory.get(TerminalFactory.java:190)
        at sbt.MainLoop$$anon$1.run(MainLoop.scala:17)
        at java.lang.Thread.run(Thread.java:748)
```